### PR TITLE
Verifying centos 7.2 support, bumping version to 0.2.1

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -14,6 +14,7 @@ verifier:
 
 platforms:
   - name: ubuntu-16.04
+  - name: centos-7.2
 
 suites:
   - name: setup

--- a/TESTING.md
+++ b/TESTING.md
@@ -28,3 +28,16 @@ Running Test Kitchen
 
 Test Kitchen test suites are defined in [.kitchen.yml](https://github.com/agileorbit-cookbooks/java/blob/master/.kitchen.yml). 
 Running `kitchen test` will cause Test Kitchen to spin up each platform VM in turn, running each of the test suites, as defined. 
+
+If you're working on the SSL portion, you'll want to setup a file called `.s2.yml` with the contents as follows: 
+
+```yaml
+s3: 
+  - aws_access_key_id: {your s3 id}
+  - aws_secret_access_key: {your s3 secret}
+  - s3_bucket: {name of your bucket}
+  - certificate_key_path: /path/to/your-cert.key
+  - certificate_path: /path/to/your-cert.pem
+```
+
+It will then pull these in with the `looker::ssl` suite and test that way. At some point, we should set these up to be mockable. 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,8 +4,8 @@ maintainer_email 'eng@deliv.co'
 license          'MIT'
 description      'Installs/Configures Looker'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.2.0'
-supports         ['ubuntu']
+version          '0.2.1'
+supports         ['ubuntu', 'centos']
 
 recipe 'looker::default', 'Installs the looker application (calls to `setup`)'
 recipe 'looker::setup',   'Installs the looker application'


### PR DESCRIPTION
While originally designed for our ubuntu 16.04 environment, I verified that the cookbook works fine in a centos 7.2 env, as well. So we'll update the metadata to reflect that, and bump the release. 