### PR TITLE
Use proper major/minor versions of looker in download

### DIFF
--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -13,7 +13,7 @@ GRAPH
     apt (>= 0.0.0)
     homebrew (>= 0.0.0)
     windows (>= 0.0.0)
-  looker (0.2.0)
+  looker (0.2.1)
     aws (>= 0.0.0)
     java (>= 0.0.0)
   ohai (5.2.0)

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -14,13 +14,8 @@ default[:looker][:looker_user_ulimit] = 4096
 default[:looker][:major_version]      = 5
 default[:looker][:minor_version]      = 2
 
-case "#{node[:looker][:major_version]}#{node[:looker][:minor_version]}"
-when '52'
-  default[:looker][:download_url] = 'https://s3.amazonaws.com/download.looker.com/aeHee2HiNeekoh3uIu6hec3W/looker-latest.jar'
-when '46'
-  default[:looker][:download_url] = 'https://s3.amazonaws.com/download.looker.com/aeHee2HiNeekoh3uIu6hec3W/looker-latest.jar'
-  # TODO: add more urls...
-end
+default[:looker][:download_url] = "https://s3.amazonaws.com/download.looker.com/aeHee2HiNeekoh3uIu6hec3W/looker-" + 
+  "#{node[:looker][:major_version]}.#{node[:looker][:minor_version]}-latest.jar"
 
 # Java 8
 default[:java]['jdk_version'] = '8'

--- a/test/integration/setup/setup_test.rb
+++ b/test/integration/setup/setup_test.rb
@@ -25,6 +25,11 @@ describe file('/home/looker/looker/looker.jar') do
   its('owner') { should eq 'looker' }
 end
 
+describe command('runuser -l looker -c "java -jar /home/looker/looker/looker.jar version"') do
+  its('stdout') { should match /5.2/ }
+  its('stderr') { should eq '' }
+end
+
 describe file('/home/looker/looker/looker') do
   it { should exist }
   it { should be_executable }


### PR DESCRIPTION
Working with looker, they gave us the naming convention of their major/minor versions. Adding that into the cookbook. 